### PR TITLE
Fix detection of printk-like calls with whitespaces

### DIFF
--- a/kernelscan.c
+++ b/kernelscan.c
@@ -3780,6 +3780,16 @@ static get_char_t HOT TARGET_CLONES parse_kernel_message(
 	if (UNLIKELY(get_token(p, t) == PARSER_EOF)) {
 		return PARSER_EOF;
 	}
+
+	/* Skip whitespaces. */
+	if (t->type == TOKEN_WHITE_SPACE) {
+		parse_whitespace(p, t, ' ');
+
+		if (UNLIKELY(get_token(p, t) == PARSER_EOF)) {
+			return PARSER_EOF;
+		}
+	}
+
 	if (t->type != TOKEN_PAREN_OPENED) {
 		for (;;) {
 			if (UNLIKELY(get_token(p, t) == PARSER_EOF))


### PR DESCRIPTION
Unexpectedly, there are function calls in the Linux kernel that violate the coding style of no whitespaces between the function
name and opens parentheses.

In the latest stable release (currently 5.11.6), there are 1468 occurrences of the type (about 0.47% of the total calls to
printk-like functions), most of them with line breaks to avoid exceeding the 80 columns, as in:

```c
// 5.11.6, in drivers/scsi/wd33c93.c:1398:
if (!( asr & ASR_INT)) {
	printk
		    ("wd33c93: Reselected without IDENTIFYn");
	lun = 0;
} else {
```

Due to kernelscan assumes there are no spaces, these calls are not identified in a normal kernelscan invocation, with no extra
options.

Fixes this by checking that the current token is a whitespace, and if so, parses it.

--
Since the occurrence of spaces is so low, I can't tell if this PR is really relevant or necessary.